### PR TITLE
Use pyparsing for contentline parsing.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-dateutil
 arrow==0.4.2
 six>1.5
+pyparsing

--- a/tests/contentline.py
+++ b/tests/contentline.py
@@ -22,6 +22,13 @@ class TestContentLine(unittest.TestCase):
             {},
             'dfqsdfjqkshflqsjdfhqs fqsfhlqs dfkqsldfkqsdfqsfqsfqsfs'
         ),
+        'ATTENDEE;CUTYPE=INDIVIDUAL;X-RESPONSE-COMMENT="asdf asdf asdfq":value':
+        ContentLine(
+            'ATTENDEE',
+            {'CUTYPE': ['INDIVIDUAL'],
+             'X-RESPONSE-COMMENT': ['"asdf asdf asdfq"']},
+            'value'
+        ),
         'DTSTART;TZID=Europe/Brussels:20131029T103000':
         ContentLine(
             'DTSTART',


### PR DESCRIPTION
Fixes an issue with quoted string parsing in param values.
